### PR TITLE
`ethereum uses PoS, it doesn't use PoW anymore`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1181,7 +1181,7 @@ Employers like to ask questions related to your application. So go over your res
   <summary>Which consensus mechanism does Ethereum use?</summary>
     <ul>
       <li>
-        Ethereum currently uses proof of Work but plans to use proof of stake in Ethereum 2.0
+        Ethereum uses a proof-of-stake (PoS) based consensus protocol. It used to use Proof-of-Work (PoW), but Ethereum switched off proof-of-work in 2022 and started using proof-of-stake instead.
       </li>
     </ul>
 </details>


### PR DESCRIPTION
Proof-of-work has now been deprecated. Ethereum no longer uses proof-of-work as part of its consensus mechanism. Instead, it uses proof-of-stake. Read official documentation [here](https://ethereum.org/en/developers/docs/consensus-mechanisms/pow/)